### PR TITLE
Adding maven-bundle-plugin to generate OSGi MANIFEST headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,30 @@
         </configuration>
       </plugin>
 
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.4.0</version>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.3.2</version>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
     
   </build>


### PR DESCRIPTION
There is no code change at all, only the OSGi MANIFEST
headers are added. This change does not cause any compatibility
issues. Please accept this pull request to allow others using this
library in an OSGi container.
