### PR TITLE
Add gradle installation example in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,6 +46,13 @@ Maven info
   *   groupId: `org.unbescape`   
   *   artifactId: `unbescape`
   *   version: (see _Current Versions_ above)
+ 
+Example usage in gradle (replace `1.1.6.RELEASE` with the current version):
+```
+dependencies {
+    implementation 'org.unbescape:unbescape:1.1.6.RELEASE'
+}
+```
 
 
 Features


### PR DESCRIPTION
Many projects show the line of code needed to include the project in Gradle, so that it can be copy-pasted right away. Also, it saves some time to those who use Maven but do not know what `groupId` and `artifactId` are.