### PR TITLE
Fixes #31 - Invalid escaping for lexicographically smallest NCR

### DIFF
--- a/src/main/java/org/unbescape/html/HtmlEscapeSymbols.java
+++ b/src/main/java/org/unbescape/html/HtmlEscapeSymbols.java
@@ -162,7 +162,7 @@ final class HtmlEscapeSymbols {
      * This constant will be used at the NCRS_BY_CODEPOINT array to specify there is no NCR associated with a
      * codepoint.
      */
-    static final short NO_NCR = (short) 0;
+    static final short NO_NCR = (short) -1;
 
 
 


### PR DESCRIPTION
This fixes the escaping of the Æ symbol (unicode codepoint 198) for HTML 4 and 5 by setting `HtmlEscapeSymbols.NO_NCR` to a value that cannot be confused with an actual array index.